### PR TITLE
Explicitly use python 2.

### DIFF
--- a/rdio/player/rdio-player
+++ b/rdio/player/rdio-player
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import gtk
 import webkit


### PR DESCRIPTION
pygtk does not exist for python3, so don't use the default python (commonly
python3 nowadays), but explicitly python2, which is the only compatible version
for this application.